### PR TITLE
grafana 8.2.4

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   grafana:
-    image: grafana/grafana:8.2.3
+    image: grafana/grafana:8.2.4
     volumes:
       - ./grafana:/var/lib/grafana
     ports:


### PR DESCRIPTION
https://github.com/grafana/grafana/releases/tag/v8.2.4
https://grafana.com/blog/2021/11/15/grafana-8.2.4-released-with-security-fixes/?utm_source=grafana_news&utm_medium=rss