### PR TITLE
feat(samba): Improve Samba Docker setup

### DIFF
--- a/docker/samba/Dockerfile
+++ b/docker/samba/Dockerfile
@@ -1,18 +1,32 @@
-FROM rockylinux:9.3-minimal
+# Builder stage for Tini
+FROM rockylinux:9.3-minimal as builder
 
-RUN microdnf -y update && microdnf -y install samba
-
-# Add Tini
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-ENV USER=user
-ENV PASSWORD=password
+# Final stage
+FROM rockylinux:9.3-minimal
 
-COPY ./start_samba.sh /usr/local/bin
-RUN chmod 775 /usr/local/bin/start_samba.sh
+# Install Samba and clean up
+RUN microdnf -y update && \
+    microdnf -y install samba && \
+    microdnf clean all
 
+# Copy Tini from the builder stage
+COPY --from=builder /tini /tini
+
+# Copy Samba configuration and startup script
+COPY ./smb.conf /etc/samba/smb.conf
+COPY ./start_samba.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/start_samba.sh
+
+# Expose Samba ports
 EXPOSE 139 445
 
+# Add a healthcheck to verify Samba is running
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD smbclient -L localhost -U% -N || exit 1
+
+# Set the entrypoint
 ENTRYPOINT ["/tini", "--", "/usr/local/bin/start_samba.sh"]

--- a/docker/samba/smb.conf
+++ b/docker/samba/smb.conf
@@ -1,0 +1,17 @@
+[global]
+    workgroup = WORKGROUP
+    server string = Samba Server %v
+    netbios name = smb_server
+    security = user
+    map to guest = bad user
+    dns proxy = no
+    # Add this to solve "protocol negotiation failed: NT_STATUS_CONNECTION_RESET"
+    server min protocol = NT1
+
+[homes]
+    comment = Home Directories
+    browseable = no
+    writable = yes
+    valid users = %S
+    create mask = 0700
+    directory mask = 0700

--- a/docker/samba/start_samba.sh
+++ b/docker/samba/start_samba.sh
@@ -1,14 +1,27 @@
 #!/bin/sh
 set -e
 
-echo start samba
+if [ -z "${USER}" ] || [ -z "${PASSWORD}" ]; then
+  echo "ERROR: The USER and PASSWORD environment variables must be set." >&2
+  exit 1
+fi
 
-# set user and password
-grep ${USER}: /etc/passwd > /dev/null || \
-    useradd ${USER}; \
-    echo -e ${PASSWORD}'\n'${PASSWORD} | pdbedit -a -u ${USER}
+echo "Configuring Samba for user: ${USER}"
 
-nmbd restart --daemon
-smbd restart --daemon
+# Create user if they don't exist
+if ! id -u "${USER}" > /dev/null 2>&1; then
+    echo "Creating system user ${USER}"
+    useradd --no-create-home --shell /usr/sbin/nologin "${USER}"
+fi
 
-tail -f /dev/null
+# Add user to Samba
+echo "Adding Samba user ${USER}"
+echo -e "${PASSWORD}\n${PASSWORD}" | pdbedit -a -u "${USER}"
+
+echo "Starting Samba services..."
+# Start nmbd in the background
+nmbd -D
+
+# Start smbd in the foreground. Tini will act as PID 1 and reap it correctly.
+# The -F flag is crucial for running in containers without a process manager like systemd.
+exec smbd -F --no-process-group


### PR DESCRIPTION
This commit introduces several improvements to the Samba Docker configuration to make it more secure, robust, and efficient.

- **Security:** Hardcoded credentials (USER/PASSWORD) have been removed from the Dockerfile. They must now be provided as environment variables at runtime. The startup script has been enhanced to validate their presence.
- **Robustness:** A default `smb.conf` is now included to provide a working configuration out-of-the-box. A `HEALTHCHECK` has also been added to the Dockerfile to monitor the Samba service.
- **Container Best Practices:** The startup script now runs `smbd` in the foreground, which is the correct way to manage a main process in a container.
- **Optimization:** The Dockerfile now uses a multi-stage build to handle the `tini` dependency and cleans up the package manager cache, reducing the final image size.